### PR TITLE
updated activerecord trait -> getUsersAuthItems

### DIFF
--- a/db/traits/ActiveRecordAccessTrait.php
+++ b/db/traits/ActiveRecordAccessTrait.php
@@ -162,6 +162,7 @@ trait ActiveRecordAccessTrait
             if (!empty(\Yii::$app->user->identity->isAdmin)) {
 
                 // All roles
+                $authRoles = [];
                 foreach ($authManager->getRoles() as $name => $role) {
 
                     if (!empty($role->description)) {
@@ -173,6 +174,7 @@ trait ActiveRecordAccessTrait
                 }
 
                 // All permissions
+                $authPermissions = [];
                 foreach ($authManager->getPermissions() as $name => $permission) {
 
                     if (!empty($permission->description)) {


### PR DESCRIPTION
 init empty permission arrays, prevent exception if your app initially has no roles or permissions

pls tag a 0.8.11