### PR TITLE
access_owner check in ActiveRecordAccessTrait::find only if user is logged in

### DIFF
--- a/db/traits/ActiveRecordAccessTrait.php
+++ b/db/traits/ActiveRecordAccessTrait.php
@@ -66,14 +66,16 @@ trait ActiveRecordAccessTrait
 
         if (self::$activeAccessTrait) {
 
-            // access owner check
-            if ($accessOwner) {
+            // access owner check only if attribute exists and user is logged in
+            $accessOwnerCheck = false;
+            if ($accessOwner && !\Yii::$app->user->isGuest) {
+                $accessOwnerCheck = true;
                 $query->where([$accessOwner => \Yii::$app->user->id]);
             }
 
             // access read check
             if ($accessRead) {
-                $queryType = ($accessOwner) ? 'orWhere' : 'where';
+                $queryType = ($accessOwnerCheck) ? 'orWhere' : 'where';
                 $authItems = implode(',', array_keys(self::getUsersAuthItems()));
                 $checkInSetQuery = self::getInSetQueryPart($accessRead, $authItems);
                 $query->$queryType($checkInSetQuery);


### PR DESCRIPTION
The current access_owner check in ActiveRecordAccessTrait :: find () can cause the models to be found even though they should be protected by acess_read.

Example: 
- We have a table app_page with access_owner (Default NULL), access_read etc. columns
- Now we insert a row (eg. with migrations or plain SQL) without setting the access_owner field to a specific UID
  -> access_owner field will be NULL
- Then we try to protect this page with access_read = 'backend'
- When a guest user requests this page model, it will see the page because the access_owner constraint in SQL will return true no matter what is set as access_read.

example SQL:

> SELECT * FROM app_page WHERE ((`access_owner IS NULL`) OR (FIND_IN_SET(access_read, "*") > 0))...`

Because `access_owner IS NULL`will return true, the access_read check is ignored.

This patch create accesss_owner where constraint only if User is logged in, so we only check  against a real UIDs.

SQL for Guests:
> SELECT * FROM app_page` WHERE (FIND_IN_SET(access_read, "*") > 0)...

SQL for logged in User:
> SELECT * FROM app_page WHERE ((access_owner=1) OR (FIND_IN_SET(access_read, "*,Editor")...

